### PR TITLE
prevent duplicate output with json flag

### DIFF
--- a/bin/oxview
+++ b/bin/oxview
@@ -74,7 +74,7 @@ def main():
                 print json.dumps(line, sort_keys=True, indent=4, separators=(',', ': '))
             else:
                 print json.dumps(line)
-        if options.pretty:
+        elif options.pretty:
             print_pretty_header(line)
             pprint.pprint(line['body'])
         else:


### PR DESCRIPTION
was printing two lines for every line
