### PR TITLE
Read timeout for Bulk API

### DIFF
--- a/bin/oxstash
+++ b/bin/oxstash
@@ -27,7 +27,7 @@ def setup_logging(options):
         level = logging.INFO
     else:
         level = logging.WARNING
-    
+
     log_format = "%(asctime)s %(levelname)s:%(name)s: %(message)s"
     logging.basicConfig(level=level, format=log_format, stream=sys.stdout)
 
@@ -71,6 +71,8 @@ def main():
                        help="Elasticsearch index to use, based on date")
     parser.add_argument('--chunk_size', action='store', type=int, default=500,
                        help="How many events to do together in a bulk operation")
+    parser.add_argument('--request_timeout', action='store', type=int, default=10,
+                       help="Read timeout for bulk api")
 
     options = parser.parse_args()
 
@@ -101,6 +103,7 @@ def main():
     action_callback = functools.partial(build_doc, options)
     bulk_streamer = elasticsearch.helpers.streaming_bulk(
         es, out_stream,
+        request_timeout=request_timeout,
         chunk_size=options.chunk_size, expand_action_callback=action_callback)
 
     for result in bulk_streamer:


### PR DESCRIPTION
@rhettg  Adding read timeout for bulk API

Reference 
 [1] https://github.com/elasticsearch/elasticsearch-py/issues/163