### PR TITLE
Remove request timeout

### DIFF
--- a/bin/oxstash
+++ b/bin/oxstash
@@ -88,11 +88,6 @@ def main():
         type=int,
         default=500,
         help="How many events to do together in a bulk operation")
-    parser.add_argument('--request_timeout',
-                        action='store',
-                        type=int,
-                        default=10,
-                        help="Read timeout for bulk api")
 
     options = parser.parse_args()
 
@@ -123,7 +118,6 @@ def main():
     action_callback = functools.partial(build_doc, options)
     bulk_streamer = elasticsearch.helpers.streaming_bulk(
         es, out_stream,
-        request_timeout=options.request_timeout,
         chunk_size=options.chunk_size,
         expand_action_callback=action_callback)
 


### PR DESCRIPTION
Remove request timeout as only some version of elasticsearch api support it. 

@rhettg 

I am getting following error after adding this param 

```
Traceback (most recent call last):
  File "/postmates/virtualenv.d/system/bin/oxstash", line 138, in <module>
    main()
  File "/postmates/virtualenv.d/system/bin/oxstash", line 130, in main
    for result in bulk_streamer:
  File "/postmates/virtualenv.d/system/local/lib/python2.7/site-packages/elasticsearch-1.0.0-py2.7.egg/elasticsearch/helpers.py", line 107, in streaming_bulk
    resp = client.bulk(bulk_actions, **kwargs)
  File "/postmates/virtualenv.d/system/local/lib/python2.7/site-packages/elasticsearch-1.0.0-py2.7.egg/elasticsearch/client/utils.py", line 70, in _wrapped
    return func(*args, params=params, **kwargs)
TypeError: bulk() got an unexpected keyword argument 'request_timeout'
Traceback (most recent call last):
  File "/postmates/sbin/postal_filter_stash", line 162, in <module>
    main()
  File "/postmates/sbin/postal_filter_stash", line 157, in main
    sys.stdout.write(context_data)
```
