### PR TITLE
Address race condition with non-writable global contexts

### DIFF
--- a/tests/context_test.py
+++ b/tests/context_test.py
@@ -170,3 +170,20 @@ class ClearContextsTestCase(TestCase):
         blueox.clear_contexts()
 
         assert_equal(blueox.current_context(), None)
+
+
+class BrokenCurrentContextTestCase(TestCase):
+    @setup
+    def broken_context(self):
+        c = blueox.Context('test')
+        assert not c.writable
+        blueox.context._add_context(c)
+
+    @teardown
+    def clear(self):
+        blueox.clear_contexts()
+
+    def test(self):
+        # Non-writable context shouldn't show up.
+        current_c = blueox.current_context()
+        assert not current_c


### PR DESCRIPTION
If a signal interrupts execution while we are registering a new context,
we could end up in a situation where we have a non-writable context.
This would result in later global calls to `blueox.set()` failing
because of an invalid context.
